### PR TITLE
Fix autogen.sh to help building mongo-c

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -79,7 +79,7 @@ function install_mongoc_driver
 {
 	cd mongo-c-driver
 	./autogen.sh 
-	configure --with-libbson=system
+	./configure --with-libbson=system
 	make install
 	cd ..
 }


### PR DESCRIPTION
The script assumed that the current working dir, `.` is in the PATH.
Now a full relative path is used to allow executing configure
on systems where this is not the case.