### PR TITLE
Implement BsonIterSubObject for the meta driver. Fixes #34 and #38.

### DIFF
--- a/mongo_wrapper_meta.c
+++ b/mongo_wrapper_meta.c
@@ -212,7 +212,11 @@ BsonIterInit(BSON_ITERATOR *it, BSON *b)
 bool
 BsonIterSubObject(BSON_ITERATOR *it, BSON *b)
 {
-	/* TODO: Need to see the Meta Driver equalient for "bson_iterator_subobject" */
+	const uint8_t *buffer;
+	uint32_t len;
+
+	bson_iter_document(it, &len, &buffer);
+	bson_init_static(b, buffer, len);
 	return true;
 }
 


### PR DESCRIPTION
The previous implementation of `BsonIterSubObject` was leaving BSON objects uninitialized, which caused crashes (#34) and missing nested fields (#38) with the mongo meta driver. This implementation fixes both issues for me.