### PR TITLE
mongo connection pool can reconnect to the server after the mongo ser…

### DIFF
--- a/mongo_fdw.c
+++ b/mongo_fdw.c
@@ -2010,7 +2010,11 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 			if (mongoc_cursor_error (mongoCursor, &error))
 			{
 				MongoFreeScanState(fmstate);
-				mongo_cleanup_connection();
+				//mongo_cleanup_connection();
+				//not clear all connection, but this connection
+				MongoDisconnect(fmstate->mongoConnection);
+                                free(fmstate->mongoConnection);
+                                fmstate->mongoConnection = NULL;
 				ereport(ERROR, (errmsg("could not iterate over mongo collection"),
 						errhint("Mongo driver error: %s", error.message)));
 			}
@@ -2019,7 +2023,11 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 				if (errorCode != MONGO_CURSOR_EXHAUSTED)
 				{
 					MongoFreeScanState(fmstate);
-					mongo_cleanup_connection();
+					//mongo_cleanup_connection();
+					//not clear all connection, but this connection
+					MongoDisconnect(fmstate->mongoConnection);
+                                	free(fmstate->mongoConnection);
+                                	fmstate->mongoConnection = NULL;
 					ereport(ERROR, (errmsg("could not iterate over mongo collection"),
 							errhint("Mongo driver cursor error code: %d", errorCode)));
 				}

--- a/mongo_fdw.c
+++ b/mongo_fdw.c
@@ -2010,6 +2010,7 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 			if (mongoc_cursor_error (mongoCursor, &error))
 			{
 				MongoFreeScanState(fmstate);
+				mongo_cleanup_connection();
 				ereport(ERROR, (errmsg("could not iterate over mongo collection"),
 						errhint("Mongo driver error: %s", error.message)));
 			}
@@ -2018,6 +2019,7 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 				if (errorCode != MONGO_CURSOR_EXHAUSTED)
 				{
 					MongoFreeScanState(fmstate);
+					mongo_cleanup_connection();
 					ereport(ERROR, (errmsg("could not iterate over mongo collection"),
 							errhint("Mongo driver cursor error code: %d", errorCode)));
 				}


### PR DESCRIPTION
After the mongo server restarted, the query result is wrong, because the mongo connecction pool can't reconnect to the server.
This problem is fixed by using mongo_cleanup_connection when there is a mongoc_cursor_error. I have verify it in my server.

I have reported this problem in #57 .
thx.