### PR TITLE
connection pool reconnect after the mongo server restarted

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ CREATE EXTENSION mongo_fdw;
 CREATE SERVER mongo_server
          FOREIGN DATA WRAPPER mongo_fdw
          OPTIONS (address '127.0.0.1', port '27017');
+-- or create server object if you use replicaSet on mongo server
+-- the last uri is: mongodb://mongo_user:****@127.0.0.1:3717,127.0.0.1:4717/admin?replicaSet=replsetName-01&readPreference=secondary
+CREATE SERVER mongo_server
+         FOREIGN DATA WRAPPER mongo_fdw
+         OPTIONS (replset 'replsetName-01', address '127.0.0.1:3717,127.0.0.1:4717', read_preference 'secondary');
 
 -- create user mapping
 CREATE USER MAPPING FOR postgres

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ The following parameters can be set on a MongoDB foreign server object:
 
   * **`address`**: the address or hostname of the MongoDB server Defaults to `127.0.0.1`
   * **`port`**: the port number of the MongoDB server. Defaults to `27017`
+  * **`replset`**: the replset name of MongoDB server. such as: '127.0.0.1:3717,192.168.0.1:4717', if use this option, the port option will be ignored.
   * **`read_preference`**: primary [default], secondary, primaryPreferred, secondaryPreferred, or nearest (meta driver only).  Defaults to `primary'
+  * **`force_server_id`**: force use mongo server's ObjectId() in column _id. Defaults to `true`
 
 The following parameters can be set on a MongoDB foreign table object:
 
@@ -87,12 +89,12 @@ CREATE EXTENSION mongo_fdw;
 -- create server object
 CREATE SERVER mongo_server
          FOREIGN DATA WRAPPER mongo_fdw
-         OPTIONS (address '127.0.0.1', port '27017');
+         OPTIONS (address '127.0.0.1', port '27017', force_server_id false);
 -- or create server object if you use replicaSet on mongo server
 -- the last uri is: mongodb://mongo_user:****@127.0.0.1:3717,127.0.0.1:4717/admin?replicaSet=replsetName-01&readPreference=secondary
 CREATE SERVER mongo_server
          FOREIGN DATA WRAPPER mongo_fdw
-         OPTIONS (replset 'replsetName-01', address '127.0.0.1:3717,127.0.0.1:4717', read_preference 'secondary');
+         OPTIONS (replset 'replsetName-01', address '127.0.0.1:3717,127.0.0.1:4717', read_preference 'secondary', force_server_id true);
 
 -- create user mapping
 CREATE USER MAPPING FOR postgres

--- a/connection.c
+++ b/connection.c
@@ -99,7 +99,7 @@ mongo_get_connection(ForeignServer *server, UserMapping *user, MongoFdwOptions *
 	if (entry->conn == NULL)
 	{
 #ifdef META_DRIVER
-		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password, opt->readPreference);
+		entry->conn = MongoConnect(opt->replSet, opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password, opt->readPreference);
 #else
 		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password);
 #endif

--- a/mongo_fdw.c
+++ b/mongo_fdw.c
@@ -286,7 +286,7 @@ MongoGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreignTableId)
 		documentSelectivity = clauselist_selectivity(root, opExpressionList,
 													 0, JOIN_INNER, NULL);
 		inputRowCount = clamp_row_est(documentCount * documentSelectivity);
-		
+
 		/*
 		 * We estimate disk costs assuming a sequential scan over the data. This is
 		 * an inaccurate assumption as Mongo scatters the data over disk pages, and
@@ -328,7 +328,7 @@ MongoGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreignTableId)
 												   NIL); /* no fdw_private data */
 
 	/* add foreign path as the only possible path */
-	add_path(baserel, foreignPath);	
+	add_path(baserel, foreignPath);
 }
 
 
@@ -810,7 +810,7 @@ MongoExecForeignInsert(EState *estate,
 			if (strcmp(slot->tts_tupleDescriptor->attrs[0]->attname.data, "__doc") == 0)
 				continue;
 
-			if (attnum == 1)
+			if (attnum == 1 && (options->force_server_id==true || isnull==true))
 			{
 				/*
 				 * Ignore the value of first column which is row identifier in MongoDb (_id)
@@ -936,7 +936,7 @@ MongoExecForeignUpdate(EState *estate,
 			int attnum = lfirst_int(lc);
 			Datum value;
 			bool isnull;
- 
+
 			if (strcmp("_id", slot->tts_tupleDescriptor->attrs[attnum - 1]->attname.data) == 0)
 				continue;
 
@@ -1157,7 +1157,7 @@ ColumnMappingHash(Oid foreignTableId, List *columnList)
  * pair, the function checks if the key appears in the column mapping hash, and
  * if the value type is compatible with the one specified for the column. If so,
  * the function converts the value and fills the corresponding tuple position.
- * The bsonDocumentKey parameter is used for recursion, and should always be 
+ * The bsonDocumentKey parameter is used for recursion, and should always be
  * passed as NULL.
  */
 static void
@@ -1176,7 +1176,7 @@ FillTupleSlot(const BSON *bsonDocument, const char *bsonDocumentKey,
 	columnMapping = (ColumnMapping *) hash_search(columnMappingHash, hashKey,
 												HASH_FIND, &handleFound);
 
-	if (columnMapping != NULL && handleFound == true && columnValues[columnMapping->columnIndex] == 0) 
+	if (columnMapping != NULL && handleFound == true && columnValues[columnMapping->columnIndex] == 0)
 	{
 		JsonLexContext* lex = NULL;
 		text*           result = NULL;
@@ -1575,7 +1575,7 @@ ColumnValue(BSON_ITERATOR *bsonIterator, Oid columnTypeId, int32 columnTypeMod)
 					value = (char*) BsonIterOid(bsonIterator);
 					value_len = 12;
 					break;
-				default: 
+				default:
 					value = (char*)BsonIterBinData(bsonIterator, (uint32_t *)&value_len);
 					break;
 			}
@@ -1990,7 +1990,7 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 	randomState = anl_init_selection_state(targetRowCount);
 
 	columnValues = (Datum *) palloc0(columnCount * sizeof(Datum));
-	columnNulls = (bool *) palloc0(columnCount * sizeof(bool));	
+	columnNulls = (bool *) palloc0(columnCount * sizeof(bool));
 
 	for (;;)
 	{
@@ -2097,7 +2097,7 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 	/* clean up */
 	MemoryContextDelete(tupleContext);
 	MongoFreeScanState(fmstate);
-	
+
 	pfree(columnValues);
 	pfree(columnNulls);
 

--- a/mongo_fdw.c
+++ b/mongo_fdw.c
@@ -1463,6 +1463,7 @@ static Datum
 ColumnValue(BSON_ITERATOR *bsonIterator, Oid columnTypeId, int32 columnTypeMod)
 {
 	Datum columnValue = 0;
+	BSON_TYPE t = BsonIterType(bsonIterator);
 
 	switch(columnTypeId)
 	{
@@ -1481,6 +1482,17 @@ ColumnValue(BSON_ITERATOR *bsonIterator, Oid columnTypeId, int32 columnTypeMod)
 		case INT8OID:
 		{
 			int64 value = BsonIterInt64(bsonIterator);
+			//most values are long type, but sometimes there are some special vlaues.
+			if (value == 0l) {
+                                switch (t) {
+                                        case 1:
+                                                value = BsonIterDouble(bsonIterator);
+                                                break;
+                                        case 16:
+                                                value = BsonIterInt32(bsonIterator);
+                                                break;
+                                }
+			}
 			columnValue = Int64GetDatum(value);
 			break;
 		}

--- a/mongo_fdw.c
+++ b/mongo_fdw.c
@@ -2010,7 +2010,11 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 			if (mongoc_cursor_error (mongoCursor, &error))
 			{
 				MongoFreeScanState(fmstate);
-				mongo_cleanup_connection();
+				//mongo_cleanup_connection();
+				//not clear all connection, but this connection
+				MongoDisconnect(fmstate->mongoConnection);
+                                free(fmstate->mongoConnection);
+                                fmstate->mongoConnection = NULL;
 				ereport(ERROR, (errmsg("could not iterate over mongo collection"),
 						errhint("Mongo driver error: %s", error.message)));
 			}
@@ -2019,7 +2023,11 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 				if (errorCode != MONGO_CURSOR_EXHAUSTED)
 				{
 					MongoFreeScanState(fmstate);
-					mongo_cleanup_connection();
+					//mongo_cleanup_connection();
+					//not clear all connection, but this connection
+					MongoDisconnect(fmstate->mongoConnection);
+                                	free(fmstate->mongoConnection);
+                                	fmstate->mongoConnection = NULL;
 					ereport(ERROR, (errmsg("could not iterate over mongo collection"),
 							errhint("Mongo driver cursor error code: %d", errorCode)));
 				}

--- a/mongo_fdw.c
+++ b/mongo_fdw.c
@@ -2010,6 +2010,7 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 			if (mongoc_cursor_error (mongoCursor, &error))
 			{
 				MongoFreeScanState(fmstate);
+				mongo_cleanup_connection();
 				ereport(ERROR, (errmsg("could not iterate over mongo collection"),
 						errhint("Mongo driver error: %s", error.message)));
 			}
@@ -2018,6 +2019,7 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 				if (errorCode != MONGO_CURSOR_EXHAUSTED)
 				{
 					MongoFreeScanState(fmstate);
+					mongo_cleanup_connection();
 					ereport(ERROR, (errmsg("could not iterate over mongo collection"),
 							errhint("Mongo driver cursor error code: %d", errorCode)));
 				}

--- a/mongo_fdw.h
+++ b/mongo_fdw.h
@@ -148,6 +148,7 @@
 #define OPTION_NAME_COLLECTION "collection"
 #define OPTION_NAME_USERNAME "username"
 #define OPTION_NAME_PASSWORD "password"
+#define OPTION_NAME_FORCESERVERID "force_server_id"
 #ifdef META_DRIVER
 #define OPTION_NAME_REPLSET "replset"
 #define OPTION_NAME_READ_PREFERENCE "read_preference"
@@ -157,6 +158,7 @@
 #define DEFAULT_IP_ADDRESS "127.0.0.1"
 #define DEFAULT_PORT_NUMBER 27017
 #define DEFAULT_DATABASE_NAME "test"
+#define DEFAULT_FORCE_SERVER_ID true
 
 /* Defines for sending queries and converting types */
 #define EQUALITY_OPERATOR_NAME "="
@@ -196,7 +198,9 @@ static const MongoValidOption ValidOptionArray[] =
 	{ OPTION_NAME_READ_PREFERENCE, ForeignServerRelationId },
 	{ OPTION_NAME_REPLSET, ForeignServerRelationId },
 #endif
-
+    {
+        OPTION_NAME_FORCESERVERID, ForeignServerRelationId
+    },
 	/* foreign table options */
 	{ OPTION_NAME_DATABASE, ForeignTableRelationId },
 	{ OPTION_NAME_COLLECTION, ForeignTableRelationId },
@@ -225,6 +229,7 @@ typedef struct MongoFdwOptions
 	char *replSet;
 	char *readPreference;
 #endif
+    bool force_server_id;
 } MongoFdwOptions;
 
 

--- a/mongo_fdw.h
+++ b/mongo_fdw.h
@@ -149,6 +149,7 @@
 #define OPTION_NAME_USERNAME "username"
 #define OPTION_NAME_PASSWORD "password"
 #ifdef META_DRIVER
+#define OPTION_NAME_URI "uri"
 #define OPTION_NAME_READ_PREFERENCE "read_preference"
 #endif
 

--- a/mongo_fdw.h
+++ b/mongo_fdw.h
@@ -149,7 +149,7 @@
 #define OPTION_NAME_USERNAME "username"
 #define OPTION_NAME_PASSWORD "password"
 #ifdef META_DRIVER
-#define OPTION_NAME_URI "uri"
+#define OPTION_NAME_REPLSET "replset"
 #define OPTION_NAME_READ_PREFERENCE "read_preference"
 #endif
 
@@ -182,7 +182,7 @@ typedef struct MongoValidOption
 
 /* Array of options that are valid for mongo_fdw */
 #ifdef META_DRIVER
-static const uint32 ValidOptionCount = 7;
+static const uint32 ValidOptionCount = 8;
 #else
 static const uint32 ValidOptionCount = 6;
 #endif
@@ -194,6 +194,7 @@ static const MongoValidOption ValidOptionArray[] =
 
 #ifdef META_DRIVER
 	{ OPTION_NAME_READ_PREFERENCE, ForeignServerRelationId },
+	{ OPTION_NAME_REPLSET, ForeignServerRelationId },
 #endif
 
 	/* foreign table options */
@@ -221,6 +222,7 @@ typedef struct MongoFdwOptions
 	char *svr_username;
 	char *svr_password;
 #ifdef META_DRIVER
+	char *replSet;
 	char *readPreference;
 #endif
 } MongoFdwOptions;

--- a/mongo_wrapper.h
+++ b/mongo_wrapper.h
@@ -31,7 +31,7 @@
 #include <bits.h>
 
 #ifdef META_DRIVER
-MONGO_CONN* MongoConnect(const char* host, const unsigned short port, char *databaseName, char *user, char *password, char *readPreference);
+MONGO_CONN* MongoConnect(const char* replSet, const char* host, const unsigned short port, char *databaseName, char *user, char *password, char *readPreference);
 #else
 MONGO_CONN* MongoConnect(const char* host, const unsigned short port, char *databaseName, char *user, char *password);
 #endif

--- a/mongo_wrapper_meta.c
+++ b/mongo_wrapper_meta.c
@@ -24,12 +24,16 @@
  * Connect to MongoDB server using Host/ip and Port number.
  */
 MONGO_CONN*
-MongoConnect(const char* host, const unsigned short port, char* databaseName, char *user, char *password, char *readPreference)
+MongoConnect(const char* replSet, const char* host, const unsigned short port, char* databaseName, char *user, char *password, char *readPreference)
 {
 	MONGO_CONN *client = NULL;
 	char* uri = NULL;
 
-	if (user && password && readPreference)
+	if (replSet && readPreference)
+                uri = bson_strdup_printf("mongodb://%s:%s@%s/%s?replicaSet=%s&readPreference=%s", user, password, host, databaseName, replSet, readPreference);
+        if (replSet)
+                uri = bson_strdup_printf("mongodb://%s:%s@%s/%s?replicaSet=%s", user, password, host, databaseName, replSet);
+        else if (user && password && readPreference)
 		uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?readPreference=%s", user, password, host, port, databaseName, readPreference);
 	else if (user && password)
 		uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s", user, password, host, port, databaseName);

--- a/option.c
+++ b/option.c
@@ -159,6 +159,14 @@ mongo_get_options(Oid foreignTableId)
 
 	readPreference = mongo_get_option_value(foreignTableId, OPTION_NAME_READ_PREFERENCE);
 #endif
+    char                    *forceServerIdName = NULL;
+    bool                    force_server_id = DEFAULT_FORCE_SERVER_ID;
+
+	forceServerIdName = mongo_get_option_value(foreignTableId, OPTION_NAME_FORCESERVERID);
+	if (forceServerIdName != NULL) {
+        if (strcmp(forceServerIdName, "false") == 0)
+            force_server_id = false;
+	}
 
 	addressName = mongo_get_option_value(foreignTableId, OPTION_NAME_ADDRESS);
 	if (addressName == NULL)
@@ -189,6 +197,7 @@ mongo_get_options(Oid foreignTableId)
 	options->collectionName = collectionName;
 	options->svr_username = svr_username;
 	options->svr_password = svr_password;
+	options->force_server_id = force_server_id;
 
 #ifdef META_DRIVER
 	options->replSet = replSet;

--- a/option.c
+++ b/option.c
@@ -153,6 +153,8 @@ mongo_get_options(Oid foreignTableId)
 	char                    *svr_username= NULL;
 	char                    *svr_password= NULL;
 #ifdef META_DRIVER
+	char                    *replSet = NULL;
+        replSet = mongo_get_option_value(foreignTableId, OPTION_NAME_REPLSET);
 	char                    *readPreference = NULL;
 
 	readPreference = mongo_get_option_value(foreignTableId, OPTION_NAME_READ_PREFERENCE);
@@ -189,6 +191,7 @@ mongo_get_options(Oid foreignTableId)
 	options->svr_password = svr_password;
 
 #ifdef META_DRIVER
+	options->replSet = replSet;
 	options->readPreference = readPreference;
 #endif
 


### PR DESCRIPTION
After the mongo server restarted, the query result is wrong, because the mongo connecction pool can't reconnect to the server.
This problem is fixed by using mongo_cleanup_connection when there is a mongoc_cursor_error. I have verify it in my server.

I have reported this problem in #57 .
thx.
