### PR TITLE
Added support for ssl in meta driver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,14 @@ The following parameters can be set on a MongoDB foreign server object:
 
   * **`address`**: the address or hostname of the MongoDB server Defaults to `127.0.0.1`
   * **`port`**: the port number of the MongoDB server. Defaults to `27017`
-  * **`read_preference`**: primary [default], secondary, primaryPreferred, secondaryPreferred, or nearest (meta driver only).  Defaults to `primary'
+  * **`read_preference`**: primary [default], secondary, primaryPreferred, secondaryPreferred, or nearest (meta driver only).  Defaults to `primary`
+  * **`ssl`**: false [default], true to enable ssl (meta driver only). See http://mongoc.org/libmongoc/current/mongoc_ssl_opt_t.html to understand the options.
+  * **`pem_file`**: SSL option;
+  * **`pem_pwd`**: SSL option;
+  * **`ca_file`**: SSL option;
+  * **`ca_dir`**: SSL option;
+  * **`crl_file`**: SSL option;
+  * **`weak_cert_validation`**: SSL option;
 
 The following parameters can be set on a MongoDB foreign table object:
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -78,7 +78,7 @@ function install_json_lib
 function install_mongoc_driver
 {
 	cd mongo-c-driver
-	./configure --with-libbson=auto
+	./configure --with-libbson=auto --enable-ssl
 	make install
 	cd ..
 }
@@ -123,4 +123,3 @@ elif [ "--with-master" == $1 ]; then
 else
 	echo "Usage: autogen.sh --[with-legacy | with-master]"
 fi
-

--- a/connection.c
+++ b/connection.c
@@ -99,7 +99,8 @@ mongo_get_connection(ForeignServer *server, UserMapping *user, MongoFdwOptions *
 	if (entry->conn == NULL)
 	{
 #ifdef META_DRIVER
-		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password, opt->readPreference);
+		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password, opt->readPreference,
+			opt->ssl, opt->pem_file, opt->pem_pwd, opt->ca_file, opt->ca_dir, opt->crl_file, opt->weak_cert_validation);
 #else
 		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password);
 #endif
@@ -146,4 +147,3 @@ mongo_release_connection(MONGO_CONN *conn)
 	 * cleanup on the backend exit.
 	 */
 }
-

--- a/mongo_fdw.c
+++ b/mongo_fdw.c
@@ -189,7 +189,6 @@ mongo_fdw_handler(PG_FUNCTION_ARGS)
 	fdwRoutine->IterateForeignScan = MongoIterateForeignScan;
 	fdwRoutine->ReScanForeignScan = MongoReScanForeignScan;
 	fdwRoutine->EndForeignScan = MongoEndForeignScan;
-	fdwRoutine->AnalyzeForeignTable = MongoAnalyzeForeignTable;
 
 	/* support for insert / update / delete */
 	fdwRoutine->ExecForeignInsert = MongoExecForeignInsert;
@@ -286,7 +285,7 @@ MongoGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreignTableId)
 		documentSelectivity = clauselist_selectivity(root, opExpressionList,
 													 0, JOIN_INNER, NULL);
 		inputRowCount = clamp_row_est(documentCount * documentSelectivity);
-		
+
 		/*
 		 * We estimate disk costs assuming a sequential scan over the data. This is
 		 * an inaccurate assumption as Mongo scatters the data over disk pages, and
@@ -328,7 +327,7 @@ MongoGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreignTableId)
 												   NIL); /* no fdw_private data */
 
 	/* add foreign path as the only possible path */
-	add_path(baserel, foreignPath);	
+	add_path(baserel, foreignPath);
 }
 
 
@@ -936,7 +935,7 @@ MongoExecForeignUpdate(EState *estate,
 			int attnum = lfirst_int(lc);
 			Datum value;
 			bool isnull;
- 
+
 			if (strcmp("_id", slot->tts_tupleDescriptor->attrs[attnum - 1]->attname.data) == 0)
 				continue;
 
@@ -1157,7 +1156,7 @@ ColumnMappingHash(Oid foreignTableId, List *columnList)
  * pair, the function checks if the key appears in the column mapping hash, and
  * if the value type is compatible with the one specified for the column. If so,
  * the function converts the value and fills the corresponding tuple position.
- * The bsonDocumentKey parameter is used for recursion, and should always be 
+ * The bsonDocumentKey parameter is used for recursion, and should always be
  * passed as NULL.
  */
 static void
@@ -1176,7 +1175,7 @@ FillTupleSlot(const BSON *bsonDocument, const char *bsonDocumentKey,
 	columnMapping = (ColumnMapping *) hash_search(columnMappingHash, hashKey,
 												HASH_FIND, &handleFound);
 
-	if (columnMapping != NULL && handleFound == true && columnValues[columnMapping->columnIndex] == 0) 
+	if (columnMapping != NULL && handleFound == true && columnValues[columnMapping->columnIndex] == 0)
 	{
 		JsonLexContext* lex = NULL;
 		text*           result = NULL;
@@ -1563,7 +1562,7 @@ ColumnValue(BSON_ITERATOR *bsonIterator, Oid columnTypeId, int32 columnTypeMod)
 					value = (char*) BsonIterOid(bsonIterator);
 					value_len = 12;
 					break;
-				default: 
+				default:
 					value = (char*)BsonIterBinData(bsonIterator, (uint32_t *)&value_len);
 					break;
 			}
@@ -1978,7 +1977,7 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 	randomState = anl_init_selection_state(targetRowCount);
 
 	columnValues = (Datum *) palloc0(columnCount * sizeof(Datum));
-	columnNulls = (bool *) palloc0(columnCount * sizeof(bool));	
+	columnNulls = (bool *) palloc0(columnCount * sizeof(bool));
 
 	for (;;)
 	{
@@ -2075,7 +2074,7 @@ MongoAcquireSampleRows(Relation relation, int errorLevel,
 	/* clean up */
 	MemoryContextDelete(tupleContext);
 	MongoFreeScanState(fmstate);
-	
+
 	pfree(columnValues);
 	pfree(columnNulls);
 

--- a/mongo_fdw.h
+++ b/mongo_fdw.h
@@ -150,6 +150,13 @@
 #define OPTION_NAME_PASSWORD "password"
 #ifdef META_DRIVER
 #define OPTION_NAME_READ_PREFERENCE "read_preference"
+#define OPTION_NAME_SSL "ssl"
+#define OPTION_NAME_PEM_FILE "pem_file"
+#define OPTION_NAME_PEM_PWD "pem_pwd"
+#define OPTION_NAME_CA_FILE "ca_file"
+#define OPTION_NAME_CA_DIR "ca_dir"
+#define OPTION_NAME_CRL_FILE "crl_file"
+#define OPTION_NAME_WEAK_CERT "weak_cert_validation"
 #endif
 
 /* Default values for option parameters */
@@ -181,7 +188,7 @@ typedef struct MongoValidOption
 
 /* Array of options that are valid for mongo_fdw */
 #ifdef META_DRIVER
-static const uint32 ValidOptionCount = 7;
+static const uint32 ValidOptionCount = 14;
 #else
 static const uint32 ValidOptionCount = 6;
 #endif
@@ -193,6 +200,13 @@ static const MongoValidOption ValidOptionArray[] =
 
 #ifdef META_DRIVER
 	{ OPTION_NAME_READ_PREFERENCE, ForeignServerRelationId },
+	{ OPTION_NAME_SSL, ForeignServerRelationId },
+	{ OPTION_NAME_PEM_FILE, ForeignServerRelationId },
+	{ OPTION_NAME_PEM_PWD, ForeignServerRelationId },
+	{ OPTION_NAME_CA_FILE, ForeignServerRelationId },
+	{ OPTION_NAME_CA_DIR, ForeignServerRelationId },
+	{ OPTION_NAME_CRL_FILE, ForeignServerRelationId },
+	{ OPTION_NAME_WEAK_CERT, ForeignServerRelationId },
 #endif
 
 	/* foreign table options */
@@ -221,6 +235,13 @@ typedef struct MongoFdwOptions
 	char *svr_password;
 #ifdef META_DRIVER
 	char *readPreference;
+ 	bool ssl;
+	char *pem_file;
+ 	char *pem_pwd;
+ 	char *ca_file;
+ 	char *ca_dir;
+ 	char *crl_file;
+ 	bool weak_cert_validation;
 #endif
 } MongoFdwOptions;
 

--- a/mongo_wrapper.h
+++ b/mongo_wrapper.h
@@ -31,7 +31,8 @@
 #include <bits.h>
 
 #ifdef META_DRIVER
-MONGO_CONN* MongoConnect(const char* host, const unsigned short port, char *databaseName, char *user, char *password, char *readPreference);
+MONGO_CONN* MongoConnect(const char* host, const unsigned short port, char *databaseName, char *user, char *password, char *readPreference,
+	bool ssl, char *pem_file, char *pem_pwd, char *ca_file, char *ca_dir, char *crl_file, bool weak_cert_validation);
 #else
 MONGO_CONN* MongoConnect(const char* host, const unsigned short port, char *databaseName, char *user, char *password);
 #endif

--- a/option.c
+++ b/option.c
@@ -154,8 +154,22 @@ mongo_get_options(Oid foreignTableId)
 	char                    *svr_password= NULL;
 #ifdef META_DRIVER
 	char                    *readPreference = NULL;
+ 	bool  									ssl = false;
+	char 										*pem_file = NULL;
+ 	char 										*pem_pwd = NULL;
+ 	char 										*ca_file = NULL;
+ 	char 										*ca_dir = NULL;
+ 	char 										*crl_file = NULL;
+ 	bool 										weak_cert_validation = false;
 
 	readPreference = mongo_get_option_value(foreignTableId, OPTION_NAME_READ_PREFERENCE);
+	ssl = mongo_get_option_value(foreignTableId, OPTION_NAME_SSL);
+	pem_file = mongo_get_option_value(foreignTableId, OPTION_NAME_PEM_FILE);
+	pem_pwd = mongo_get_option_value(foreignTableId, OPTION_NAME_PEM_PWD);
+	ca_file = mongo_get_option_value(foreignTableId, OPTION_NAME_CA_FILE);
+	ca_dir = mongo_get_option_value(foreignTableId, OPTION_NAME_CA_DIR);
+	crl_file = mongo_get_option_value(foreignTableId, OPTION_NAME_CRL_FILE);
+	weak_cert_validation = mongo_get_option_value(foreignTableId, OPTION_NAME_WEAK_CERT);
 #endif
 
 	addressName = mongo_get_option_value(foreignTableId, OPTION_NAME_ADDRESS);
@@ -190,6 +204,13 @@ mongo_get_options(Oid foreignTableId)
 
 #ifdef META_DRIVER
 	options->readPreference = readPreference;
+	options->ssl = ssl;
+	options->pem_file = pem_file;
+	options->pem_pwd = pem_pwd;
+	options->ca_file = ca_file;
+	options->ca_dir = ca_dir;
+	options->crl_file = crl_file;
+	options->weak_cert_validation = weak_cert_validation;
 #endif
 
 	return options;
@@ -242,4 +263,3 @@ mongo_get_option_value(Oid foreignTableId, const char *optionName)
 	}
 	return optionValue;
 }
-


### PR DESCRIPTION
Fixes: https://github.com/EnterpriseDB/mongo_fdw/issues/68

Added SSL support in the meta driver.

I also cleaned a duplicated line: fdwRoutine->AnalyzeForeignTable = MongoAnalyzeForeignTable;
