### PR TITLE
Support for authentication database in the CREATE SERVER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@
 
 # pgregress results directory
 results/
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following parameters can be set on a MongoDB foreign server object:
   * **`address`**: the address or hostname of the MongoDB server Defaults to `127.0.0.1`
   * **`port`**: the port number of the MongoDB server. Defaults to `27017`
   * **`authentication_database`**: database against which user will be authenticated against. Only valid with password based authentication. Defaults to per same database as the MongoDB collection database.
+  * **`replica_set`**: replica set the server is member of. If set, driver will auto-connect to correct primary in the replica set when writing.  
   * **`read_preference`**: primary [default], secondary, primaryPreferred, secondaryPreferred, or nearest (meta driver only).  Defaults to `primary`
   * **`ssl`**: false [default], true to enable ssl (meta driver only). See http://mongoc.org/libmongoc/current/mongoc_ssl_opt_t.html to understand the options.
   * **`pem_file`**: SSL option;

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following parameters can be set on a MongoDB foreign server object:
 
   * **`address`**: the address or hostname of the MongoDB server Defaults to `127.0.0.1`
   * **`port`**: the port number of the MongoDB server. Defaults to `27017`
+  * **`authentication_database`**: database against which user will be authenticated against. Only valid with password based authentication. Defaults to per same database as the MongoDB collection database.
   * **`read_preference`**: primary [default], secondary, primaryPreferred, secondaryPreferred, or nearest (meta driver only).  Defaults to `primary`
   * **`ssl`**: false [default], true to enable ssl (meta driver only). See http://mongoc.org/libmongoc/current/mongoc_ssl_opt_t.html to understand the options.
   * **`pem_file`**: SSL option;

--- a/connection.c
+++ b/connection.c
@@ -99,7 +99,8 @@ mongo_get_connection(ForeignServer *server, UserMapping *user, MongoFdwOptions *
 	if (entry->conn == NULL)
 	{
 #ifdef META_DRIVER
-		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password, opt->authenticationDatabase, opt->readPreference,
+		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password,
+		opt->authenticationDatabase, opt->replicaSet, opt->readPreference,
 			opt->ssl, opt->pem_file, opt->pem_pwd, opt->ca_file, opt->ca_dir, opt->crl_file, opt->weak_cert_validation);
 #else
 		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password);

--- a/connection.c
+++ b/connection.c
@@ -99,7 +99,7 @@ mongo_get_connection(ForeignServer *server, UserMapping *user, MongoFdwOptions *
 	if (entry->conn == NULL)
 	{
 #ifdef META_DRIVER
-		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password, opt->readPreference,
+		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password, opt->authenticationDatabase, opt->readPreference,
 			opt->ssl, opt->pem_file, opt->pem_pwd, opt->ca_file, opt->ca_dir, opt->crl_file, opt->weak_cert_validation);
 #else
 		entry->conn = MongoConnect(opt->svr_address, opt->svr_port, opt->svr_database, opt->svr_username, opt->svr_password);

--- a/mongo_fdw.h
+++ b/mongo_fdw.h
@@ -151,6 +151,7 @@
 #ifdef META_DRIVER
 #define OPTION_NAME_READ_PREFERENCE "read_preference"
 #define OPTION_NAME_AUTHENTICATION_DATABASE "authentication_database"
+#define OPTION_NAME_REPLICA_SET "replica_set"
 #define OPTION_NAME_SSL "ssl"
 #define OPTION_NAME_PEM_FILE "pem_file"
 #define OPTION_NAME_PEM_PWD "pem_pwd"
@@ -189,7 +190,7 @@ typedef struct MongoValidOption
 
 /* Array of options that are valid for mongo_fdw */
 #ifdef META_DRIVER
-static const uint32 ValidOptionCount = 15;
+static const uint32 ValidOptionCount = 16;
 #else
 static const uint32 ValidOptionCount = 6;
 #endif
@@ -202,6 +203,7 @@ static const MongoValidOption ValidOptionArray[] =
 #ifdef META_DRIVER
 	{ OPTION_NAME_READ_PREFERENCE, ForeignServerRelationId },
 	{ OPTION_NAME_AUTHENTICATION_DATABASE, ForeignServerRelationId },
+	{ OPTION_NAME_REPLICA_SET, ForeignServerRelationId },
 	{ OPTION_NAME_SSL, ForeignServerRelationId },
 	{ OPTION_NAME_PEM_FILE, ForeignServerRelationId },
 	{ OPTION_NAME_PEM_PWD, ForeignServerRelationId },
@@ -238,6 +240,7 @@ typedef struct MongoFdwOptions
 #ifdef META_DRIVER
 	char *readPreference;
 	char *authenticationDatabase;
+	char *replicaSet;
  	bool ssl;
 	char *pem_file;
  	char *pem_pwd;

--- a/mongo_fdw.h
+++ b/mongo_fdw.h
@@ -150,6 +150,7 @@
 #define OPTION_NAME_PASSWORD "password"
 #ifdef META_DRIVER
 #define OPTION_NAME_READ_PREFERENCE "read_preference"
+#define OPTION_NAME_AUTHENTICATION_DATABASE "authentication_database"
 #define OPTION_NAME_SSL "ssl"
 #define OPTION_NAME_PEM_FILE "pem_file"
 #define OPTION_NAME_PEM_PWD "pem_pwd"
@@ -188,7 +189,7 @@ typedef struct MongoValidOption
 
 /* Array of options that are valid for mongo_fdw */
 #ifdef META_DRIVER
-static const uint32 ValidOptionCount = 14;
+static const uint32 ValidOptionCount = 15;
 #else
 static const uint32 ValidOptionCount = 6;
 #endif
@@ -200,6 +201,7 @@ static const MongoValidOption ValidOptionArray[] =
 
 #ifdef META_DRIVER
 	{ OPTION_NAME_READ_PREFERENCE, ForeignServerRelationId },
+	{ OPTION_NAME_AUTHENTICATION_DATABASE, ForeignServerRelationId },
 	{ OPTION_NAME_SSL, ForeignServerRelationId },
 	{ OPTION_NAME_PEM_FILE, ForeignServerRelationId },
 	{ OPTION_NAME_PEM_PWD, ForeignServerRelationId },
@@ -235,6 +237,7 @@ typedef struct MongoFdwOptions
 	char *svr_password;
 #ifdef META_DRIVER
 	char *readPreference;
+	char *authenticationDatabase;
  	bool ssl;
 	char *pem_file;
  	char *pem_pwd;

--- a/mongo_wrapper.h
+++ b/mongo_wrapper.h
@@ -32,7 +32,7 @@
 
 #ifdef META_DRIVER
 MONGO_CONN* MongoConnect(const char* host, const unsigned short port, char *databaseName, char *user, char *password,
-    char *authenticationDatabase, char *readPreference,	bool ssl, char *pem_file, char *pem_pwd, char *ca_file,
+    char *authenticationDatabase,char *replicaSet, char *readPreference,	bool ssl, char *pem_file, char *pem_pwd, char *ca_file,
     char *ca_dir, char *crl_file, bool weak_cert_validation);
 #else
 MONGO_CONN* MongoConnect(const char* host, const unsigned short port, char *databaseName, char *user, char *password);

--- a/mongo_wrapper.h
+++ b/mongo_wrapper.h
@@ -31,8 +31,9 @@
 #include <bits.h>
 
 #ifdef META_DRIVER
-MONGO_CONN* MongoConnect(const char* host, const unsigned short port, char *databaseName, char *user, char *password, char *readPreference,
-	bool ssl, char *pem_file, char *pem_pwd, char *ca_file, char *ca_dir, char *crl_file, bool weak_cert_validation);
+MONGO_CONN* MongoConnect(const char* host, const unsigned short port, char *databaseName, char *user, char *password,
+    char *authenticationDatabase, char *readPreference,	bool ssl, char *pem_file, char *pem_pwd, char *ca_file,
+    char *ca_dir, char *crl_file, bool weak_cert_validation);
 #else
 MONGO_CONN* MongoConnect(const char* host, const unsigned short port, char *databaseName, char *user, char *password);
 #endif

--- a/mongo_wrapper_meta.c
+++ b/mongo_wrapper_meta.c
@@ -25,7 +25,7 @@
  */
 MONGO_CONN*
 MongoConnect(const char* host, const unsigned short port, char* databaseName, char *user, char *password,
-    char *authenticationDatabase, char *readPreference, bool ssl, char *pem_file,
+    char *authenticationDatabase, char *replicaSet, char *readPreference, bool ssl, char *pem_file,
 	char *pem_pwd, char *ca_file, char *ca_dir, char *crl_file, bool weak_cert_validation)
 {
 	MONGO_CONN *client = NULL;
@@ -33,19 +33,39 @@ MongoConnect(const char* host, const unsigned short port, char* databaseName, ch
 
 	if (user && password)
 	    if (authenticationDatabase)
-	        if (readPreference)
-		        uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?readPreference=%s&ssl=%s&authSource=%s", user, password, host, port, databaseName, readPreference, ssl ? "true" : "false",authenticationDatabase);
+	        if (replicaSet)
+	            if (readPreference)
+		            uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?readPreference=%s&ssl=%s&authSource=%s&replicaSet=%s", user, password, host, port, databaseName, readPreference, ssl ? "true" : "false",authenticationDatabase,replicaSet);
+		        else
+		            uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?ssl=%s&authSource=%s&replicaSet=%s", user, password, host, port, databaseName,  ssl ? "true" : "false",authenticationDatabase,replicaSet);
 		    else
-		        uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?ssl=%s&authSource=%s", user, password, host, port, databaseName,  ssl ? "true" : "false",authenticationDatabase);
+   	            if (readPreference)
+   		            uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?readPreference=%s&ssl=%s&authSource=%s", user, password, host, port, databaseName, readPreference, ssl ? "true" : "false",authenticationDatabase);
+   		        else
+   		            uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?ssl=%s&authSource=%s", user, password, host, port, databaseName,  ssl ? "true" : "false",authenticationDatabase);
 		else
-	        if (readPreference)
-		        uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?readPreference=%s&ssl=%s", user, password, host, port, databaseName, readPreference, ssl ? "true" : "false");
+	        if (replicaSet)
+    	        if (readPreference)
+	    	        uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?readPreference=%s&ssl=%s&replicaSet=%s", user, password, host, port, databaseName, readPreference, ssl ? "true" : "false",replicaSet);
+		        else
+		            uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?ssl=%s&replicaSet=%s", user, password, host, port, databaseName,  ssl ? "true" : "false",replicaSet);
 		    else
-		        uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?ssl=%s", user, password, host, port, databaseName,  ssl ? "true" : "false");
-	else if (readPreference)
-		uri = bson_strdup_printf ("mongodb://%s:%hu/%s?readPreference=%s&ssl=%s", host, port, databaseName, readPreference, ssl ? "true" : "false");
+    	        if (readPreference)
+	    	        uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?readPreference=%s&ssl=%s", user, password, host, port, databaseName, readPreference, ssl ? "true" : "false");
+		        else
+		            uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?ssl=%s", user, password, host, port, databaseName,  ssl ? "true" : "false");
 	else
-		uri = bson_strdup_printf ("mongodb://%s:%hu/%s?ssl=%s", host, port, databaseName, ssl ? "true" : "false");
+        if (replicaSet)
+        	if (readPreference)
+		        uri = bson_strdup_printf ("mongodb://%s:%hu/%s?readPreference=%s&ssl=%s&replicaSet=%s", host, port, databaseName, readPreference, ssl ? "true" : "false",replicaSet);
+        	else
+        		uri = bson_strdup_printf ("mongodb://%s:%hu/%s?ssl=%s&replicaSet=%s", host, port, databaseName, ssl ? "true" : "false",replicaSet);
+        else
+        	if (readPreference)
+        	    uri = bson_strdup_printf ("mongodb://%s:%hu/%s?readPreference=%s&ssl=%s", host, port, databaseName, readPreference, ssl ? "true" : "false");
+            else
+            	uri = bson_strdup_printf ("mongodb://%s:%hu/%s?ssl=%s", host, port, databaseName, ssl ? "true" : "false");
+
 
 	client = mongoc_client_new(uri);
 

--- a/mongo_wrapper_meta.c
+++ b/mongo_wrapper_meta.c
@@ -24,16 +24,24 @@
  * Connect to MongoDB server using Host/ip and Port number.
  */
 MONGO_CONN*
-MongoConnect(const char* host, const unsigned short port, char* databaseName, char *user, char *password, char *readPreference, bool ssl, char *pem_file,
+MongoConnect(const char* host, const unsigned short port, char* databaseName, char *user, char *password,
+    char *authenticationDatabase, char *readPreference, bool ssl, char *pem_file,
 	char *pem_pwd, char *ca_file, char *ca_dir, char *crl_file, bool weak_cert_validation)
 {
 	MONGO_CONN *client = NULL;
 	char* uri = NULL;
 
-	if (user && password && readPreference)
-		uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?readPreference=%s&ssl=%s", user, password, host, port, databaseName, readPreference, ssl ? "true" : "false");
-	else if (user && password)
-		uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?ssl=%s", user, password, host, port, databaseName,  ssl ? "true" : "false");
+	if (user && password)
+	    if (authenticationDatabase)
+	        if (readPreference)
+		        uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?readPreference=%s&ssl=%s&authSource=%s", user, password, host, port, databaseName, readPreference, ssl ? "true" : "false",authenticationDatabase);
+		    else
+		        uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?ssl=%s&authSource=%s", user, password, host, port, databaseName,  ssl ? "true" : "false",authenticationDatabase);
+		else
+	        if (readPreference)
+		        uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?readPreference=%s&ssl=%s", user, password, host, port, databaseName, readPreference, ssl ? "true" : "false");
+		    else
+		        uri = bson_strdup_printf ("mongodb://%s:%s@%s:%hu/%s?ssl=%s", user, password, host, port, databaseName,  ssl ? "true" : "false");
 	else if (readPreference)
 		uri = bson_strdup_printf ("mongodb://%s:%hu/%s?readPreference=%s&ssl=%s", host, port, databaseName, readPreference, ssl ? "true" : "false");
 	else

--- a/option.c
+++ b/option.c
@@ -155,6 +155,7 @@ mongo_get_options(Oid foreignTableId)
 #ifdef META_DRIVER
 	char                    *readPreference = NULL;
 	char                    *authenticationDatabase = NULL;
+	char                    *replicaSet = NULL;
  	bool  									ssl = false;
 	char 										*pem_file = NULL;
  	char 										*pem_pwd = NULL;
@@ -165,6 +166,7 @@ mongo_get_options(Oid foreignTableId)
 
 	readPreference = mongo_get_option_value(foreignTableId, OPTION_NAME_READ_PREFERENCE);
 	authenticationDatabase = mongo_get_option_value(foreignTableId, OPTION_NAME_AUTHENTICATION_DATABASE);
+	replicaSet = mongo_get_option_value(foreignTableId, OPTION_NAME_REPLICA_SET);
 	ssl = mongo_get_option_value(foreignTableId, OPTION_NAME_SSL);
 	pem_file = mongo_get_option_value(foreignTableId, OPTION_NAME_PEM_FILE);
 	pem_pwd = mongo_get_option_value(foreignTableId, OPTION_NAME_PEM_PWD);
@@ -207,6 +209,7 @@ mongo_get_options(Oid foreignTableId)
 #ifdef META_DRIVER
 	options->readPreference = readPreference;
 	options->authenticationDatabase = authenticationDatabase;
+	options->replicaSet = replicaSet;
 	options->ssl = ssl;
 	options->pem_file = pem_file;
 	options->pem_pwd = pem_pwd;

--- a/option.c
+++ b/option.c
@@ -154,6 +154,7 @@ mongo_get_options(Oid foreignTableId)
 	char                    *svr_password= NULL;
 #ifdef META_DRIVER
 	char                    *readPreference = NULL;
+	char                    *authenticationDatabase = NULL;
  	bool  									ssl = false;
 	char 										*pem_file = NULL;
  	char 										*pem_pwd = NULL;
@@ -163,6 +164,7 @@ mongo_get_options(Oid foreignTableId)
  	bool 										weak_cert_validation = false;
 
 	readPreference = mongo_get_option_value(foreignTableId, OPTION_NAME_READ_PREFERENCE);
+	authenticationDatabase = mongo_get_option_value(foreignTableId, OPTION_NAME_AUTHENTICATION_DATABASE);
 	ssl = mongo_get_option_value(foreignTableId, OPTION_NAME_SSL);
 	pem_file = mongo_get_option_value(foreignTableId, OPTION_NAME_PEM_FILE);
 	pem_pwd = mongo_get_option_value(foreignTableId, OPTION_NAME_PEM_PWD);
@@ -204,6 +206,7 @@ mongo_get_options(Oid foreignTableId)
 
 #ifdef META_DRIVER
 	options->readPreference = readPreference;
+	options->authenticationDatabase = authenticationDatabase;
 	options->ssl = ssl;
 	options->pem_file = pem_file;
 	options->pem_pwd = pem_pwd;


### PR DESCRIPTION
Introduced authentication_database option in response to issue #51 .

Had same issue and the solution seemed obvious as the underlying driver already supports authSource= uri option.
