### PR TITLE
Add PostgreSQL version 10 to all Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,6 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6))
-    $(error PostgreSQL 9.3, 9.4, 9.5 or 9.6 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10))
+    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10 is required to compile this extension)
 endif

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,6 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10))
-    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10.0))
+    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10.0 is required to compile this extension)
 endif

--- a/Makefile.legacy
+++ b/Makefile.legacy
@@ -47,6 +47,6 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6))
-    $(error PostgreSQL 9.3, 9.4, 9.5 or 9.6 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10))
+    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10 is required to compile this extension)
 endif

--- a/Makefile.legacy
+++ b/Makefile.legacy
@@ -47,6 +47,6 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10))
-    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10.0))
+    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10.0 is required to compile this extension)
 endif

--- a/Makefile.meta
+++ b/Makefile.meta
@@ -43,6 +43,6 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10))
-    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10.0))
+    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10.0 is required to compile this extension)
 endif

--- a/Makefile.meta
+++ b/Makefile.meta
@@ -43,6 +43,6 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6))
-    $(error PostgreSQL 9.3, 9.4, 9.5 or 9.6 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10))
+    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10 is required to compile this extension)
 endif


### PR DESCRIPTION
This PR adds PostgreSQL version 10 to the version check in all Makefiles.

Should fix #88 