### PR TITLE
[RFC] Bump version of mongo-c-driver

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -14,6 +14,10 @@
 #
 #-------------------------------------------------------------------------
 
+
+MONGOC_VERSION=1.9.5
+JSONC_VERSION=0.12.1-20160607
+
 if [ "$#" -ne 1 ]; then
     echo "Usage: autogen.sh --[with-legacy | with-master]"
     exit
@@ -25,10 +29,10 @@ fi
 function checkout_mongo_driver
 {
 	rm -rf mongo-c-driver
-	wget https://github.com/mongodb/mongo-c-driver/releases/download/1.3.1/mongo-c-driver-1.3.1.tar.gz
-	tar -zxvf mongo-c-driver-1.3.1.tar.gz
-	mv mongo-c-driver-1.3.1 mongo-c-driver
-	rm -rf mongo-c-driver-1.3.1.tar.gz
+	wget https://github.com/mongodb/mongo-c-driver/releases/download/$MONGOC_VERSION/mongo-c-driver-$MONGOC_VERSION.tar.gz
+	tar -zxvf mongo-c-driver-$MONGOC_VERSION.tar.gz
+	mv mongo-c-driver-$MONGOC_VERSION mongo-c-driver
+	rm -rf mongo-c-driver-$MONGOC_VERSION.tar.gz
 }
 
 ###
@@ -49,13 +53,13 @@ function checkout_json_lib
 {
 	echo $PWD
 	rm -rf json-c
-	wget https://github.com/json-c/json-c/archive/json-c-0.12.1-20160607.tar.gz
-	tar -zxvf json-c-0.12.1-20160607.tar.gz
-	mv json-c-json-c-0.12.1-20160607 json-c
+	wget https://github.com/json-c/json-c/archive/json-c-$JSONC_VERSION.tar.gz
+	tar -zxvf json-c-$JSONC_VERSION.tar.gz
+	mv json-c-json-c-$JSONC_VERSION json-c
 	cd json-c
 	patch -p1 < ../json_compilation_error.patch
 	cd ..
-	rm -rf json-c-0.12-20140410.tar.gz
+	rm -rf json-c-$JSONC_VERSION.tar.gz
 	echo $PWD
 }
 


### PR DESCRIPTION
Hello.
I had some problems with installing mongo_fdw in `postgres:10.3` docker container. Bumping version of mongo-c-driver basically did the job (it was about missing variables in headers), but I would like to leave some things to discussion here:

* What are the requirements for bumping version of mongo-c-driver in autogen.sh?
* I can install correct versions of `libbson` and `libmongoc` manually, but I would still need to run `autogen.sh` to properly install `mongo_fdw`, at least to create `config.h` and install `json-c`. IMO user should have a possibility to pass option like `--with-libmongoc=system` (similar to `--with-libbson=system` when installing libmongoc) and avoid downloading mongo-c-driver.
* Or maybe user should be able to specify what version of mongo-c-driver he want to install (via env, CLI,...)
* Or maybe `make -f Makefile.meta && make -f Makefile.meta install` (from instruction) should be able to do this installation without running `autogen.sh` (now it's missing `config.h` for example)
* Or maybe I am missing something?

Thanks in advance for all comments
