### PR TITLE
Fix build for PostgreSQL 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,6 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10.0))
-    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10.0 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10.0 11.0))
+    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6, 10.0 or 11.0 is required to compile this extension)
 endif

--- a/Makefile.legacy
+++ b/Makefile.legacy
@@ -47,6 +47,6 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10.0))
-    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10.0 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10.0 11.0))
+    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6, 10.0 or 11.0 is required to compile this extension)
 endif

--- a/Makefile.meta
+++ b/Makefile.meta
@@ -43,6 +43,6 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10.0))
-    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10.0 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10.0 11.0))
+    $(error PostgreSQL 9.3, 9.4, 9.5, 9.6, 10.0 or 11.0 is required to compile this extension)
 endif

--- a/mongo_fdw.c
+++ b/mongo_fdw.c
@@ -932,7 +932,11 @@ MongoExecForeignUpdate(EState *estate,
 	/* Get the id that was passed up as a resjunk column */
 	datum = ExecGetJunkAttribute(planSlot, 1, &isNull);
 
+#if (PG_VERSION_NUM >= 110000)
+	columnName = get_attname(foreignTableId, 1, false);
+#else
 	columnName = get_relid_attribute_name(foreignTableId, 1);
+#endif
 
 	typoid = get_atttype(foreignTableId, 1);
 
@@ -1032,7 +1036,11 @@ MongoExecForeignDelete(EState *estate,
 	/* Get the id that was passed up as a resjunk column */
 	datum = ExecGetJunkAttribute(planSlot, 1, &isNull);
 
+#if (PG_VERSION_NUM >= 110000)
+	columnName = get_attname(foreignTableId, 1, false);
+#else
 	columnName = get_relid_attribute_name(foreignTableId, 1);
+#endif
 
 	typoid = get_atttype(foreignTableId, 1);
 
@@ -1148,7 +1156,11 @@ ColumnMappingHash(Oid foreignTableId, List *columnList)
 		bool handleFound = false;
 		void *hashKey = NULL;
 
+#if (PG_VERSION_NUM >= 110000)
+		columnName = get_attname(foreignTableId, columnId, false);
+#else
 		columnName = get_relid_attribute_name(foreignTableId, columnId);
+#endif
 		hashKey = (void *) columnName;
 
 		columnMapping = (ColumnMapping *) hash_search(columnMappingHash, hashKey,

--- a/mongo_query.c
+++ b/mongo_query.c
@@ -210,7 +210,11 @@ QueryDocument(Oid relationId, List *opExpressionList, ForeignScanState *scanStat
 		paramNode = (Param *) FindArgumentOfType(argumentList, T_Param);
 
 		columnId = column->varattno;
+#if (PG_VERSION_NUM >= 110000)
+		columnName = get_attname(relationId, columnId, false);
+#else
 		columnName = get_relid_attribute_name(relationId, columnId);
+#endif
 
 		if (constant != NULL)
 			AppendConstantValue(queryDocument, columnName, constant);
@@ -238,7 +242,11 @@ QueryDocument(Oid relationId, List *opExpressionList, ForeignScanState *scanStat
 		BSON r;
 
 		columnId = column->varattno;
+#if (PG_VERSION_NUM >= 110000)
+		columnName = get_attname(relationId, columnId, false);
+#else
 		columnName = get_relid_attribute_name(relationId, columnId);
+#endif
 
 		/* find all expressions that correspond to the column */
 		columnOperatorList = ColumnOperatorList(column, comparisonOperatorList);


### PR DESCRIPTION
This includes the required fixes to build mongo_fdw against PG11. All changes are backwards compatible, I verified mongo_fdw can still be built against PG 10, 9.6, 9.5 and 9.4 including the changes from this PR. Building against 9.3 seems to be broken without these changes already.