### PR TITLE
fix: change default collation allowance

### DIFF
--- a/mongo_query.c
+++ b/mongo_query.c
@@ -1475,7 +1475,10 @@ foreign_expr_walker(Node *node, foreign_glob_cxt *glob_cxt,
 				 */
 				collation = c->constcollid;
 				if (collation == InvalidOid ||
-					collation == DEFAULT_COLLATION_OID)
+					collation == DEFAULT_COLLATION_OID ||
+                    collation == C_COLLATION_OID ||
+                    collation == POSIX_COLLATION_OID
+                    )
 					state = FDW_COLLATE_NONE;
 				else
 					state = FDW_COLLATE_UNSAFE;
@@ -1498,7 +1501,10 @@ foreign_expr_walker(Node *node, foreign_glob_cxt *glob_cxt,
 				 */
 				collation = p->paramcollid;
 				if (collation == InvalidOid ||
-					collation == DEFAULT_COLLATION_OID)
+					collation == DEFAULT_COLLATION_OID ||
+                    collation == C_COLLATION_OID ||
+                    collation == POSIX_COLLATION_OID
+                    )
 					state = FDW_COLLATE_NONE;
 				else
 					state = FDW_COLLATE_UNSAFE;
@@ -1558,7 +1564,11 @@ foreign_expr_walker(Node *node, foreign_glob_cxt *glob_cxt,
 				else if (inner_cxt.state == FDW_COLLATE_SAFE &&
 						 collation == inner_cxt.collation)
 					state = FDW_COLLATE_SAFE;
-				else if (collation == DEFAULT_COLLATION_OID)
+				else if (
+                    collation == DEFAULT_COLLATION_OID ||
+                    collation == C_COLLATION_OID ||
+                    collation == POSIX_COLLATION_OID
+                )
 					state = FDW_COLLATE_NONE;
 				else
 					state = FDW_COLLATE_UNSAFE;
@@ -1585,7 +1595,11 @@ foreign_expr_walker(Node *node, foreign_glob_cxt *glob_cxt,
 				else if (inner_cxt.state == FDW_COLLATE_SAFE &&
 						 collation == inner_cxt.collation)
 					state = FDW_COLLATE_SAFE;
-				else if (collation == DEFAULT_COLLATION_OID)
+				else if (
+                    collation == DEFAULT_COLLATION_OID ||
+                    collation == C_COLLATION_OID ||
+                    collation == POSIX_COLLATION_OID
+                )
 					state = FDW_COLLATE_NONE;
 				else
 					state = FDW_COLLATE_UNSAFE;
@@ -1721,7 +1735,11 @@ foreign_expr_walker(Node *node, foreign_glob_cxt *glob_cxt,
 				else if (inner_cxt.state == FDW_COLLATE_SAFE &&
 						 collation == inner_cxt.collation)
 					state = FDW_COLLATE_SAFE;
-				else if (collation == DEFAULT_COLLATION_OID)
+				else if (
+                    collation == DEFAULT_COLLATION_OID ||
+                    collation == C_COLLATION_OID ||
+                    collation == POSIX_COLLATION_OID
+                    )
 					state = FDW_COLLATE_NONE;
 				else
 					state = FDW_COLLATE_UNSAFE;
@@ -1760,12 +1778,20 @@ foreign_expr_walker(Node *node, foreign_glob_cxt *glob_cxt,
 					/*
 					 * Non-default collation always beats default.
 					 */
-					if (outer_cxt->collation == DEFAULT_COLLATION_OID)
+					if (
+                        outer_cxt->collation == DEFAULT_COLLATION_OID ||
+                        outer_cxt->collation == C_COLLATION_OID ||
+                        outer_cxt->collation == POSIX_COLLATION_OID
+                        )
 					{
 						/* Override previous parent state */
 						outer_cxt->collation = collation;
 					}
-					else if (collation != DEFAULT_COLLATION_OID)
+					else if (
+                        collation != DEFAULT_COLLATION_OID &&
+                        collation != C_COLLATION_OID &&
+                        collation != POSIX_COLLATION_OID
+                        )
 					{
 						/*
 						 * Conflict; show state as indeterminate.  We don't


### PR DESCRIPTION
Make provision for C_COLLATION_OID and POSIX_COLLATION_OID, which are also built-in types.

I'm not 100% sure what the impact will be, but everywhere specifically DEFAULT_COLLATION_OID was used, the other two were allowed as well.

This fixes #169 and pushes down ObjectID queries for all columns.